### PR TITLE
test(vm): characterization tests for vm_create and vm_details handlers

### DIFF
--- a/backend/api/v1/vm_create_test.go
+++ b/backend/api/v1/vm_create_test.go
@@ -1,0 +1,135 @@
+package apiv1_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apiv1 "pvmss/api/v1"
+	"pvmss/database"
+	"pvmss/state"
+)
+
+// newOfflineVMState builds a StateManager backed by a real in-memory DB with
+// bootstrap completed and offline mode enabled. Handlers are called directly
+// (bypassing JWT middleware); usernameFromCtx returns "" when the auth context
+// key is absent. Offline mode makes the VM handlers characterize the
+// no-Proxmox code paths (settings-derived data / offline gates) deterministically.
+func newOfflineVMState(t *testing.T) state.StateManager {
+	t.Helper()
+	db, err := database.OpenMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.CompleteBootstrap("test"))
+
+	sm := state.MakeAppStateWithDB(db)
+	require.NoError(t, sm.LoadSettingsFromDB())
+	sm.SetOfflineMode()
+	return sm
+}
+
+// vmRequest builds a GET request carrying the httprouter `:id` param in context,
+// mirroring how the router injects it at runtime so requireVMID resolves.
+func vmRequest(method, target, vmid string) *http.Request {
+	r := httptest.NewRequest(method, target, nil)
+	if vmid != "" {
+		ctx := context.WithValue(r.Context(), httprouter.ParamsKey, httprouter.Params{
+			{Key: "id", Value: vmid},
+		})
+		r = r.WithContext(ctx)
+	}
+	return r
+}
+
+// ── GET /api/v1/vm-create/settings (offline) ───────────────────────────────────
+
+// TestGetVMCreateSettings_Offline_ReturnsSettingsDerivedData characterizes the
+// offline path: ProxmoxConnected is false and nodes/storages/bridges/ISOs are
+// derived from settings (not a live snapshot).
+func TestGetVMCreateSettings_Offline_ReturnsSettingsDerivedData(t *testing.T) {
+	sm := newOfflineVMState(t)
+
+	s := sm.GetSettings()
+	s.EnabledStorages = []string{"pve1:local-lvm"}
+	s.VMBRs = []string{"pve1:vmbr0"}
+	s.ISOs = []string{"local:iso/debian-12.iso"}
+	s.Tags = []string{"web", "db"}
+	require.NoError(t, sm.SetSettings(s))
+
+	h := apiv1.MakeVMCreateHandler(sm)
+	w := httptest.NewRecorder()
+	h.GetSettings(w, httptest.NewRequest(http.MethodGet, "/api/v1/vm-create/settings", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp apiv1.VMCreateSettingsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.False(t, resp.ProxmoxConnected, "offline mode must report not connected")
+
+	require.Len(t, resp.Storages, 1)
+	assert.Equal(t, "local-lvm", resp.Storages[0].Name)
+	assert.Equal(t, "pve1", resp.Storages[0].Node)
+
+	require.Len(t, resp.Bridges, 1)
+	assert.Equal(t, "vmbr0", resp.Bridges[0].Name)
+	assert.Equal(t, "pve1", resp.Bridges[0].Node)
+
+	require.Len(t, resp.ISOs, 1)
+	assert.Equal(t, "local:iso/debian-12.iso", resp.ISOs[0].VolID)
+	assert.Equal(t, "debian-12.iso", resp.ISOs[0].Name, "ISO name is the basename of the volid")
+
+	assert.ElementsMatch(t, []string{"web", "db"}, resp.Tags)
+}
+
+// TestGetVMCreateSettings_Offline_OnlyEnabledStoragesAppear characterizes the
+// allowlist behavior offline: storages/bridges come solely from the settings
+// allowlists, so anything not enabled never appears in the response.
+func TestGetVMCreateSettings_Offline_OnlyEnabledStoragesAppear(t *testing.T) {
+	sm := newOfflineVMState(t)
+
+	s := sm.GetSettings()
+	s.EnabledStorages = []string{"pve1:allowed-a", "pve1:allowed-b"}
+	require.NoError(t, sm.SetSettings(s))
+
+	h := apiv1.MakeVMCreateHandler(sm)
+	w := httptest.NewRecorder()
+	h.GetSettings(w, httptest.NewRequest(http.MethodGet, "/api/v1/vm-create/settings", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp apiv1.VMCreateSettingsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	names := make([]string, 0, len(resp.Storages))
+	for _, st := range resp.Storages {
+		names = append(names, st.Name)
+	}
+	assert.ElementsMatch(t, []string{"allowed-a", "allowed-b"}, names)
+	assert.NotContains(t, names, "denied", "a storage not in EnabledStorages must not appear")
+}
+
+// TestGetVMCreateSettings_Offline_EmptyListsWhenNoSettings characterizes the
+// zero-value case: with empty allowlists the response carries empty (non-nil)
+// slices so the JSON is `[]` rather than `null`.
+func TestGetVMCreateSettings_Offline_EmptyListsWhenNoSettings(t *testing.T) {
+	sm := newOfflineVMState(t)
+
+	h := apiv1.MakeVMCreateHandler(sm)
+	w := httptest.NewRecorder()
+	h.GetSettings(w, httptest.NewRequest(http.MethodGet, "/api/v1/vm-create/settings", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp apiv1.VMCreateSettingsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.NotNil(t, resp.Nodes)
+	assert.NotNil(t, resp.Storages)
+	assert.NotNil(t, resp.Bridges)
+	assert.Empty(t, resp.Storages)
+	assert.Empty(t, resp.Bridges)
+}

--- a/backend/api/v1/vm_details_test.go
+++ b/backend/api/v1/vm_details_test.go
@@ -1,0 +1,136 @@
+package apiv1_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apiv1 "pvmss/api/v1"
+	"pvmss/proxmox"
+)
+
+// ── GetVMConfig gate behavior ───────────────────────────────────────────────────
+//
+// GetVMConfig checks the `:id` param first, then the offline gate. In offline
+// mode it returns 503 (proxmox_offline) BEFORE any snapshot lookup — there is no
+// offline snapshot path for VM config today (see finding in plan 005). These
+// tests lock that ordering so the perf refactor (plan 006) regresses loudly.
+
+func TestGetVMConfig_InvalidVMID_ReturnsBadRequest(t *testing.T) {
+	sm := newOfflineVMState(t)
+	h := apiv1.MakeVMDetailsHandler(sm)
+
+	w := httptest.NewRecorder()
+	h.GetVMConfig(w, vmRequest(http.MethodGet, "/api/v1/vms/abc/config", "abc"))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid vm id")
+}
+
+func TestGetVMConfig_ZeroVMID_ReturnsBadRequest(t *testing.T) {
+	sm := newOfflineVMState(t)
+	h := apiv1.MakeVMDetailsHandler(sm)
+
+	w := httptest.NewRecorder()
+	h.GetVMConfig(w, vmRequest(http.MethodGet, "/api/v1/vms/0/config", "0"))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetVMConfig_MissingVMIDParam_ReturnsBadRequest(t *testing.T) {
+	sm := newOfflineVMState(t)
+	h := apiv1.MakeVMDetailsHandler(sm)
+
+	// No httprouter param injected — requireVMID can't parse and must 400.
+	w := httptest.NewRecorder()
+	h.GetVMConfig(w, httptest.NewRequest(http.MethodGet, "/api/v1/vms//config", nil))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetVMConfig_Offline_ReturnsServiceUnavailable(t *testing.T) {
+	sm := newOfflineVMState(t)
+	h := apiv1.MakeVMDetailsHandler(sm)
+
+	w := httptest.NewRecorder()
+	h.GetVMConfig(w, vmRequest(http.MethodGet, "/api/v1/vms/100/config", "100"))
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), "proxmox_offline")
+}
+
+func TestGetVMMetrics_Offline_ReturnsServiceUnavailable(t *testing.T) {
+	sm := newOfflineVMState(t)
+	h := apiv1.MakeVMDetailsHandler(sm)
+
+	w := httptest.NewRecorder()
+	h.GetVMMetrics(w, vmRequest(http.MethodGet, "/api/v1/vms/100/metrics", "100"))
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), "proxmox_offline")
+}
+
+func TestGetVMSettings_Offline_ReturnsServiceUnavailable(t *testing.T) {
+	sm := newOfflineVMState(t)
+	h := apiv1.MakeVMDetailsHandler(sm)
+
+	w := httptest.NewRecorder()
+	h.GetVMSettings(w, vmRequest(http.MethodGet, "/api/v1/vms/100/settings", "100"))
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), "proxmox_offline")
+}
+
+// ── Network parse contract ──────────────────────────────────────────────────────
+//
+// GetVMConfig builds its Networks field from proxmox.ExtractNetworkInterfaces.
+// The offline gate blocks a handler-level integration test, so we lock the parse
+// contract directly on the exported func — this is the network shape the perf
+// refactor (plan 006) must preserve. parseDisks/parseCloudInit are unexported and
+// thus not reachable from this external test package (see plan 005 finding).
+
+func TestExtractNetworkInterfaces_ParsesConfigLine(t *testing.T) {
+	cfg := map[string]any{
+		"net0": "virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0,tag=42,rate=10,mtu=1500,firewall=1",
+		"net1": "e1000=11:22:33:44:55:66,bridge=vmbr1,link_down=1",
+	}
+
+	ifaces := proxmox.ExtractNetworkInterfaces(cfg)
+	require.Len(t, ifaces, 2)
+
+	n0 := ifaces[0]
+	assert.Equal(t, "net0", n0.Index)
+	assert.Equal(t, "virtio", n0.Model)
+	assert.Equal(t, "AA:BB:CC:DD:EE:FF", n0.MACAddress)
+	assert.Equal(t, "vmbr0", n0.Bridge)
+	assert.Equal(t, 42, n0.VLAN)
+	assert.Equal(t, "10", n0.Rate)
+	assert.Equal(t, "1500", n0.MTU)
+	assert.True(t, n0.Firewall)
+	assert.False(t, n0.LinkDown)
+
+	n1 := ifaces[1]
+	assert.Equal(t, "net1", n1.Index)
+	assert.Equal(t, "e1000", n1.Model)
+	assert.Equal(t, "vmbr1", n1.Bridge)
+	assert.True(t, n1.LinkDown)
+	assert.False(t, n1.Firewall)
+}
+
+func TestExtractNetworkInterfaces_NilConfig(t *testing.T) {
+	assert.Nil(t, proxmox.ExtractNetworkInterfaces(nil))
+}
+
+func TestGetVMConfig_ResponseTypeHasParsedNetworks(t *testing.T) {
+	// Documents that the config response carries parsed NetworkInterface structs,
+	// keeping the JSON contract stable for the frontend/perf refactor.
+	var resp apiv1.VMConfigResponse
+	resp.Networks = proxmox.ExtractNetworkInterfaces(map[string]any{
+		"net0": "virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0",
+	})
+	require.Len(t, resp.Networks, 1)
+	assert.Equal(t, "vmbr0", resp.Networks[0].Bridge)
+}

--- a/docs/plans/advisor/README.md
+++ b/docs/plans/advisor/README.md
@@ -19,7 +19,7 @@ run every verification gate, and update your row when done.
 | 002  | Fix stale/inaccurate docs (README env table, CLAUDE.md, dead CSRF var) | P1 | S | 001 (file overlap) | DONE |
 | 003  | Add frontend check/lint/test + race-detector jobs to CI | P1 | S | — | DONE (PR #98: incl. fixing 170 lint errors, lint blocking) |
 | 004  | Auth handler table-driven tests (login/exchange/refresh/PVE-admin) | P1 | L | 003 | DONE |
-| 005  | VM create + VM details characterization tests | P2 | M | 003, 004 (scaffold) | TODO |
+| 005  | VM create + VM details characterization tests | P2 | M | 003, 004 (scaffold) | DONE |
 | 006  | Parallelize Proxmox fetches (pool N+1, VM detail waterfall) | P2 | M | 005 | TODO |
 | 007  | Extract shared settings-update helper (admin handler dedup) | P3 | M | 005 | TODO |
 | 008  | Quick wins: remove unused adapter-auto, extend Dependabot | P3 | S | — | TODO |


### PR DESCRIPTION
## Summary

Adds offline characterization tests for the two top-churn, previously **untested** VM handlers (`vm_create.go`, `vm_details.go`), locking current behavior ahead of the plan 006 perf refactor that parallelizes `GetVMConfig`'s sequential Proxmox calls. Implements `docs/plans/advisor/005-vm-handler-tests.md`.

**Characterization only — no source changes** to `vm_create.go` / `vm_details.go` / `vm_create_resolve.go`.

## Tests added

`backend/api/v1/vm_create_test.go`
- `GetSettings` offline → 200 with settings-derived nodes/storages/bridges/ISOs
- Allowlist filtering: only `EnabledStorages` entries appear
- Empty (non-nil) slices when unconfigured (`[]` not `null`)

`backend/api/v1/vm_details_test.go`
- `GetVMConfig` / `GetVMMetrics` / `GetVMSettings`: 400 on invalid/zero/missing vmid; 503 `proxmox_offline` gate ordering
- `ExtractNetworkInterfaces` parse contract (network shape the perf refactor must preserve)

## Findings (plan deviations)

1. **Plan Step 3 "offline 200 with seeded snapshot" is impossible.** `GetVMConfig` returns `errOffline` (503) immediately after the vmid check — there is no offline snapshot path. No `state` test seam required; offline short-circuits. Tests characterize the real 503 behavior. If plan 006 wants 200-with-snapshot offline, it must add that path.
2. **`parseDisks`/`parseCloudInit` are unexported** → unreachable from `package apiv1_test`. Network parsing is locked via the exported `proxmox.ExtractNetworkInterfaces` instead. Those funcs are pure and untouched by 006's call-parallelization (low regression risk).

## Test plan

- [x] `GO_TEST_ENVIRONMENT=1 PVMSS_OFFLINE=true go test -run 'TestGetVMCreateSettings|TestGetVMConfig|TestGetVMMetrics|TestGetVMSettings|TestExtractNetworkInterfaces' ./api/v1/ -v -race` → 12 pass, no races
- [x] Full offline suite: `go test -timeout=5m ./...` → 739 pass
- [x] `golangci-lint run --timeout=3m` → 0 issues
- [x] In-scope source files unchanged (empty `git diff`)