### PR TITLE
refactor(api): extract persistSettingsChange helper (admin handler dedup)

### DIFF
--- a/backend/api/v1/admin_tags.go
+++ b/backend/api/v1/admin_tags.go
@@ -10,6 +10,7 @@ import (
 
 	"pvmss/constants"
 	"pvmss/proxmox"
+	"pvmss/state"
 )
 
 var tagNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,50}$`)
@@ -84,19 +85,11 @@ func (h *AdminMutationsHandler) CreateTag(w http.ResponseWriter, r *http.Request
 	newTags := make([]string, len(settings.Tags), len(settings.Tags)+1)
 	copy(newTags, settings.Tags)
 	newTags = append(newTags, req.Name)
-	if h.state.HasDB() {
-		if err := h.state.SetTags(newTags, usernameFromCtx(r)); err != nil {
-			writeAppError(w, err)
-			return
-		}
-	} else {
-		newSettings := *settings
-		newSettings.Tags = newTags
-		newSettings.Limits.Nodes = copyNodeLimits(settings.Limits.Nodes)
-		if err := h.state.SetSettings(&newSettings); err != nil {
-			writeAppError(w, err)
-			return
-		}
+	if !h.persistSettingsChange(w, r,
+		func(changedBy string) error { return h.state.SetTags(newTags, changedBy) },
+		func(s *state.AppSettings) *state.AppSettings { ns := *s; ns.Tags = newTags; return &ns },
+	) {
+		return
 	}
 	w.WriteHeader(http.StatusCreated)
 	writeJSON(w, AdminTagResponse{Name: req.Name})
@@ -194,19 +187,11 @@ func (h *AdminMutationsHandler) DeleteTag(w http.ResponseWriter, r *http.Request
 		errBadRequest(w, "tag not found")
 		return
 	}
-	if h.state.HasDB() {
-		if err := h.state.SetTags(newTags, usernameFromCtx(r)); err != nil {
-			writeAppError(w, err)
-			return
-		}
-	} else {
-		newSettings := *settings
-		newSettings.Tags = newTags
-		newSettings.Limits.Nodes = copyNodeLimits(settings.Limits.Nodes)
-		if err := h.state.SetSettings(&newSettings); err != nil {
-			writeAppError(w, err)
-			return
-		}
+	if !h.persistSettingsChange(w, r,
+		func(changedBy string) error { return h.state.SetTags(newTags, changedBy) },
+		func(s *state.AppSettings) *state.AppSettings { ns := *s; ns.Tags = newTags; return &ns },
+	) {
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/api/v1/admin_tags_test.go
+++ b/backend/api/v1/admin_tags_test.go
@@ -1,0 +1,152 @@
+package apiv1_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apiv1 "pvmss/api/v1"
+	"pvmss/database"
+	"pvmss/state"
+)
+
+// newTagStateDB builds a StateManager backed by a real in-memory DB (HasDB
+// true) so CreateTag/DeleteTag exercise the SetTags audit path.
+func newTagStateDB(t *testing.T) state.StateManager {
+	t.Helper()
+	db, err := database.OpenMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.CompleteBootstrap("test"))
+	sm := state.MakeAppStateWithDB(db)
+	require.NoError(t, sm.LoadSettingsFromDB())
+	return sm
+}
+
+// newTagStateNoDB builds a StateManager with no DB (HasDB false) so
+// CreateTag/DeleteTag exercise the in-memory SetSettings path.
+func newTagStateNoDB(t *testing.T) state.StateManager {
+	t.Helper()
+	return state.MakeAppState()
+}
+
+// nameParamRequest injects the httprouter `:name` param the way the router does
+// at runtime, so DeleteTag resolves it from context.
+func nameParamRequest(method, target, name string) *http.Request {
+	r := httptest.NewRequest(method, target, nil)
+	ctx := context.WithValue(r.Context(), httprouter.ParamsKey, httprouter.Params{
+		{Key: "name", Value: name},
+	})
+	return r.WithContext(ctx)
+}
+
+func createTagBody(name string) *bytes.Buffer {
+	b, _ := json.Marshal(apiv1.CreateTagRequest{Name: name})
+	return bytes.NewBuffer(b)
+}
+
+// ── CreateTag ───────────────────────────────────────────────────────────────
+
+func TestCreateTag_DB_PersistsAndReturns201(t *testing.T) {
+	sm := newTagStateDB(t)
+	h := apiv1.MakeAdminMutationsHandler(sm)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/tags", createTagBody("web"))
+	h.CreateTag(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	assert.Contains(t, sm.GetTags(), "web", "DB path must persist the new tag")
+}
+
+func TestCreateTag_NoDB_PersistsAndReturns201(t *testing.T) {
+	sm := newTagStateNoDB(t)
+	h := apiv1.MakeAdminMutationsHandler(sm)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/tags", createTagBody("web"))
+	h.CreateTag(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	assert.Contains(t, sm.GetTags(), "web", "in-memory path must persist the new tag")
+}
+
+func TestCreateTag_Duplicate_ReturnsBadRequest(t *testing.T) {
+	sm := newTagStateDB(t)
+	h := apiv1.MakeAdminMutationsHandler(sm)
+
+	first := httptest.NewRecorder()
+	h.CreateTag(first, httptest.NewRequest(http.MethodPost, "/api/v1/admin/tags", createTagBody("dup")))
+	require.Equal(t, http.StatusCreated, first.Code)
+
+	w := httptest.NewRecorder()
+	h.CreateTag(w, httptest.NewRequest(http.MethodPost, "/api/v1/admin/tags", createTagBody("dup")))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "already exists")
+}
+
+func TestCreateTag_InvalidName_ReturnsBadRequest(t *testing.T) {
+	sm := newTagStateDB(t)
+	h := apiv1.MakeAdminMutationsHandler(sm)
+
+	w := httptest.NewRecorder()
+	h.CreateTag(w, httptest.NewRequest(http.MethodPost, "/api/v1/admin/tags", createTagBody("bad tag!")))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── DeleteTag ───────────────────────────────────────────────────────────────
+
+func TestDeleteTag_DB_RemovesAndReturns204(t *testing.T) {
+	sm := newTagStateDB(t)
+	h := apiv1.MakeAdminMutationsHandler(sm)
+
+	create := httptest.NewRecorder()
+	h.CreateTag(create, httptest.NewRequest(http.MethodPost, "/api/v1/admin/tags", createTagBody("web")))
+	require.Equal(t, http.StatusCreated, create.Code)
+
+	w := httptest.NewRecorder()
+	h.DeleteTag(w, nameParamRequest(http.MethodDelete, "/api/v1/admin/tags/web", "web"))
+	require.Equal(t, http.StatusNoContent, w.Code)
+	assert.NotContains(t, sm.GetTags(), "web", "DB path must remove the tag")
+}
+
+func TestDeleteTag_NoDB_RemovesAndReturns204(t *testing.T) {
+	sm := newTagStateNoDB(t)
+	h := apiv1.MakeAdminMutationsHandler(sm)
+
+	create := httptest.NewRecorder()
+	h.CreateTag(create, httptest.NewRequest(http.MethodPost, "/api/v1/admin/tags", createTagBody("web")))
+	require.Equal(t, http.StatusCreated, create.Code)
+
+	w := httptest.NewRecorder()
+	h.DeleteTag(w, nameParamRequest(http.MethodDelete, "/api/v1/admin/tags/web", "web"))
+	require.Equal(t, http.StatusNoContent, w.Code)
+	assert.NotContains(t, sm.GetTags(), "web", "in-memory path must remove the tag")
+}
+
+func TestDeleteTag_RequiredPvmssTag_ReturnsBadRequest(t *testing.T) {
+	sm := newTagStateDB(t)
+	h := apiv1.MakeAdminMutationsHandler(sm)
+
+	w := httptest.NewRecorder()
+	h.DeleteTag(w, nameParamRequest(http.MethodDelete, "/api/v1/admin/tags/pvmss", "pvmss"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "pvmss")
+}
+
+func TestDeleteTag_NotFound_ReturnsBadRequest(t *testing.T) {
+	sm := newTagStateDB(t)
+	h := apiv1.MakeAdminMutationsHandler(sm)
+
+	w := httptest.NewRecorder()
+	h.DeleteTag(w, nameParamRequest(http.MethodDelete, "/api/v1/admin/tags/ghost", "ghost"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "not found")
+}

--- a/backend/api/v1/request.go
+++ b/backend/api/v1/request.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 
 	"github.com/julienschmidt/httprouter"
+
+	"pvmss/state"
 )
 
 // decodeBody decodes the JSON request body into v. On failure it writes a 400
@@ -28,4 +30,34 @@ func requireVMID(w http.ResponseWriter, r *http.Request) (int, bool) {
 		return 0, false
 	}
 	return vmid, true
+}
+
+// persistSettingsChange applies a settings mutation through the correct backend:
+// when a DB is present it runs the DB-backed setter (which records the audit
+// entry via changedBy); otherwise it applies the in-memory mutation and calls
+// SetSettings. The in-memory path preserves the copyNodeLimits defensive copy so
+// the stored settings never share the node-limits map with the live snapshot.
+// Returns true on success; on failure it has already written the error response,
+// so the caller must return immediately when it returns false.
+func (h *AdminMutationsHandler) persistSettingsChange(
+	w http.ResponseWriter,
+	r *http.Request,
+	dbWrite func(changedBy string) error,
+	memMutate func(s *state.AppSettings) *state.AppSettings,
+) bool {
+	if h.state.HasDB() {
+		if err := dbWrite(usernameFromCtx(r)); err != nil {
+			writeAppError(w, err)
+			return false
+		}
+		return true
+	}
+	settings := h.state.GetSettings()
+	newSettings := memMutate(settings)
+	newSettings.Limits.Nodes = copyNodeLimits(settings.Limits.Nodes)
+	if err := h.state.SetSettings(newSettings); err != nil {
+		writeAppError(w, err)
+		return false
+	}
+	return true
 }

--- a/docs/plans/advisor/README.md
+++ b/docs/plans/advisor/README.md
@@ -21,7 +21,7 @@ run every verification gate, and update your row when done.
 | 004  | Auth handler table-driven tests (login/exchange/refresh/PVE-admin) | P1 | L | 003 | DONE |
 | 005  | VM create + VM details characterization tests | P2 | M | 003, 004 (scaffold) | DONE |
 | 006  | Parallelize Proxmox fetches (pool N+1, VM detail waterfall) | P2 | M | 005 | DONE |
-| 007  | Extract shared settings-update helper (admin handler dedup) | P3 | M | 005 | TODO |
+| 007  | Extract shared settings-update helper (admin handler dedup) | P3 | M | 005 | DONE (helper folds admin_tags; limits/profiles left inline per STOP conditions) |
 | 008  | Quick wins: remove unused adapter-auto, extend Dependabot | P3 | S | — | TODO |
 | 009  | Spike: bulk VM operations (design + API + open questions) | P3 | M | — | TODO |
 | 010  | Spike: VM clone functionality (design + API + open questions) | P3 | M | — | TODO |


### PR DESCRIPTION
## Summary
Plan 007 (advisor). Removes the duplicated DB-vs-in-memory settings-mutation block from the admin tag handlers.

- **New helper** `persistSettingsChange` in `request.go`: runs the DB-backed setter (with `usernameFromCtx` audit) when a DB is present, else applies the in-memory mutation and calls `SetSettings`, preserving the `copyNodeLimits` defensive copy. Returns `bool` (false = error already written, caller returns).
- **`admin_tags.go`**: `CreateTag` and `DeleteTag` now call the helper — the near-identical inline `if HasDB {…} else {…}` blocks are gone (net −13 lines in that file).

## Left inline (per plan STOP conditions)
- **`admin_limits.go UpdateLimits`**: rebuilds the whole `Limits` struct and does per-node DB upsert/delete — more than "set one field".
- **`admin_profiles.go`** (Create/Update/Delete/Toggle): in-memory path adds `DefaultVMProfiles()` fallback + `copyVMProfiles`; DB path needs error-returning `vmProfileConfigToDB` conversion. Distinct shape; folding would leak profile concerns into the generic helper.

## Tests
- Added `admin_tags_test.go` (Step 0 characterization): CreateTag/DeleteTag over **both** DB and in-memory paths, plus duplicate/invalid/required-tag/not-found cases — committed **before** the refactor as the safety baseline.
- No public response shape or status code changed.

## Verification
- `GO_TEST_ENVIRONMENT=1 PVMSS_OFFLINE=true go test -timeout=5m ./...` → **748 pass**
- `golangci-lint run --timeout=3m` → **0 issues**