### PR TITLE
chore(deps): remove unused adapter-auto + extend Dependabot to gomod & npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/docs/plans/advisor/README.md
+++ b/docs/plans/advisor/README.md
@@ -22,7 +22,7 @@ run every verification gate, and update your row when done.
 | 005  | VM create + VM details characterization tests | P2 | M | 003, 004 (scaffold) | DONE |
 | 006  | Parallelize Proxmox fetches (pool N+1, VM detail waterfall) | P2 | M | 005 | DONE |
 | 007  | Extract shared settings-update helper (admin handler dedup) | P3 | M | 005 | DONE (helper folds admin_tags; limits/profiles left inline per STOP conditions) |
-| 008  | Quick wins: remove unused adapter-auto, extend Dependabot | P3 | S | — | TODO |
+| 008  | Quick wins: remove unused adapter-auto, extend Dependabot | P3 | S | — | DONE (lockfile is text `bun.lock` not `bun.lockb`) |
 | 009  | Spike: bulk VM operations (design + API + open questions) | P3 | M | — | TODO |
 | 010  | Spike: VM clone functionality (design + API + open questions) | P3 | M | — | TODO |
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -16,7 +16,6 @@
         "@eslint/js": "^10.0.1",
         "@internationalized/date": "^3.12.2",
         "@lucide/svelte": "^1.17.0",
-        "@sveltejs/adapter-auto": "^7.0.1",
         "@sveltejs/adapter-static": "^3.0.10",
         "@sveltejs/kit": "^2.64.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -212,8 +211,6 @@
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.10", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA=="],
-
-    "@sveltejs/adapter-auto": ["@sveltejs/adapter-auto@7.0.1", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ=="],
 
     "@sveltejs/adapter-static": ["@sveltejs/adapter-static@3.0.10", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,6 @@
 		"@eslint/js": "^10.0.1",
 		"@internationalized/date": "^3.12.2",
 		"@lucide/svelte": "^1.17.0",
-		"@sveltejs/adapter-auto": "^7.0.1",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.64.0",
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",


### PR DESCRIPTION
## Summary
Plan 008 (advisor) — two hygiene quick wins.

1. **Remove `@sveltejs/adapter-auto`**: unused devDependency. `svelte.config.js` imports `adapter-static` only; no reference to `adapter-auto` in `svelte.config.js` or `src/`. Lockfile regenerated (`bun install` → 1 package removed).
2. **Extend Dependabot**: add `gomod` (`/backend`) and `npm` (`/frontend`) ecosystems alongside the existing `github-actions`, so Go and frontend deps get weekly automated PRs.

## Notes
- Lockfile is text **`bun.lock`** (bun 1.3.14), not the binary `bun.lockb` the plan referenced.
- Orphaned `dependabot/npm_and_yarn/*` remote branches from a prior config remain — maintainer cleanup, out of scope.

## Verification
- `grep -rn adapter-auto` in package.json/bun.lock/svelte.config.js → no matches
- `bun run check` → 0 errors (pre-existing CSS `line-clamp` warning unrelated)
- `yamllint .github/dependabot.yml` → clean; three ecosystems present